### PR TITLE
Commands that fail should return a non-zero exit status.

### DIFF
--- a/bin/karo
+++ b/bin/karo
@@ -5,7 +5,8 @@ require 'karo'
 begin
   Karo::CLI.start(ARGV)
 rescue SystemExit, Interrupt
-  puts "Exiting"
+  STDERR.puts "Exiting"
 rescue Exception => e
-  puts e
+  STDERR.puts "karo: Error: #{e}"
+  return 1
 end

--- a/lib/karo/common.rb
+++ b/lib/karo/common.rb
@@ -22,6 +22,9 @@ module Karo
     def run_it(cmd, verbose=false)
       say cmd, :green if verbose
       system cmd unless options[:dryrun]
+      if $?.exitstatus
+        raise "Non-zero exit code (#{$?.exitstatus}) returned from #{cmd.strip}"
+      end
     end
 
     def git_repo


### PR DESCRIPTION
This resolves #10.
- Raise an exception when a system command fails with a non-zero
  exception. (This could be a custom exception.)
- bin/karo should return a non-zero exit status when an exception is
  rescued.
- Error messages should be printed on STDERR, not STDOUT.
- Inform the user when a system interrupt is triggered on STDERR; this
  emulates the behaviour of most other UNIX commands.
