### PR TITLE
Fix for pull request #11

### DIFF
--- a/bin/karo
+++ b/bin/karo
@@ -8,5 +8,6 @@ rescue SystemExit, Interrupt
   STDERR.puts "Exiting"
 rescue => e
   STDERR.puts "karo: Error: #{e}"
+  STDERR.puts e.backtrace
   exit 1
 end

--- a/bin/karo
+++ b/bin/karo
@@ -6,7 +6,7 @@ begin
   Karo::CLI.start(ARGV)
 rescue SystemExit, Interrupt
   STDERR.puts "Exiting"
-rescue Exception => e
+rescue => e
   STDERR.puts "karo: Error: #{e}"
   exit 1
 end

--- a/bin/karo
+++ b/bin/karo
@@ -8,5 +8,5 @@ rescue SystemExit, Interrupt
   STDERR.puts "Exiting"
 rescue Exception => e
   STDERR.puts "karo: Error: #{e}"
-  return 1
+  exit 1
 end

--- a/bin/karo
+++ b/bin/karo
@@ -5,7 +5,8 @@ require 'karo'
 begin
   Karo::CLI.start(ARGV)
 rescue SystemExit, Interrupt
-  puts "Exiting"
+  STDERR.puts "Exiting"
 rescue Exception => e
-  puts e
+  STDERR.puts "karo: Error: #{e}"
+  return 1
 end

--- a/lib/karo/common.rb
+++ b/lib/karo/common.rb
@@ -22,7 +22,7 @@ module Karo
     def run_it(cmd, verbose=false)
       say cmd, :green if verbose
       system cmd unless options[:dryrun]
-      if $?.exitstatus
+      if $?.exitstatus != 0
         raise "Non-zero exit code (#{$?.exitstatus}) returned from #{cmd.strip}"
       end
     end

--- a/lib/karo/common.rb
+++ b/lib/karo/common.rb
@@ -22,6 +22,9 @@ module Karo
     def run_it(cmd, verbose=false)
       say cmd, :green if verbose
       system cmd unless options[:dryrun]
+      if $?.exitstatus
+        raise "Non-zero exit code (#{$?.exitstatus}) returned from #{cmd.strip}"
+      end
     end
 
     def git_repo


### PR DESCRIPTION
As per description of pull request #11, this has the following features:
* This resolves #10.
* Raise an exception when a system command fails with a non-zero exception.
* `bin/karo` should return a non-zero exit status when an exception is rescued.
* Error messages should be printed on STDERR, not STDOUT.
* Inform the user when a system interrupt is triggered on STDERR; this emulates the behaviour of most other UNIX commands.

Additionally, my pull request adds:
* Fix for `unexpected return (LocalJumpError)` error
* Removes rescue of `Exception`.  For why this change is necessary see [this SO answer][1]
* Add backtrace to STDERR for unhandled exceptions so user can diagnose errors better
* Test for non-zero exit status after running cmd.  Was checking for `nil` but should be checking for non-zero value.

[1]: http://stackoverflow.com/a/10048406/848668