### PR TITLE
String replacement templates in commands

### DIFF
--- a/lib/karo/common.rb
+++ b/lib/karo/common.rb
@@ -12,6 +12,9 @@ module Karo
 
       if commands && commands[namespace] && commands[namespace][command]
         command = commands[namespace][command]
+        command.sub! "{{user}}", configuration["user"]
+        command.sub! "{{host}}", configuration["host"]
+        command.sub! "{{path}}", configuration["path"]
       end
 
       extras = extras.flatten(1).uniq.join(" ").strip


### PR DESCRIPTION
Added string replacement for user/host/path to dynamically generate commands from existing config.

Example usage:

```yaml
staging:
  host: example.com
  user: admin
  path: /data/example
  commands:
    client:
      getconfig: scp {{user}}@{{host}}:{{path}}/current/config/application.yml config/application.yml
```

This results in the command getting built as `scp admin@example.com/data/example/current/config/application.yml config/application.yml`

Feel free to suggest different string replacement template, I couldn't find any best practices for it in ruby/rails and I'm not marries to the handlebars style template. 